### PR TITLE
fix unit-test

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -3,10 +3,12 @@
 const src = require('..')
 const dist = require('../dist')
 
+const qs = require('querystring')
+
 test('qs.src', () => {
-  expect(src.f()).toBe('foo=foo&bar=bar&zoo=zoo&haa=haa')
+  expect(qs.parse(src.f())).toEqual(qs.parse('foo=foo&bar=bar&zoo=zoo&haa=haa'))
 })
 
 test('qs.dist', () => {
-  expect(dist.f()).toBe('foo=foo&bar=bar&zoo=zoo&haa=haa')
+  expect(qs.parse(dist.f())).toEqual(qs.parse('foo=foo&bar=bar&zoo=zoo&haa=haa'))
 })

--- a/jscrambler.json
+++ b/jscrambler.json
@@ -1,9 +1,9 @@
 {
   "keys": {
-    "accessKey": "5A9460E67570F59D100CE5FB88899667334E48D6",
-    "secretKey": "B59FD04E7A80CCD038F25C84C208FBD2DF5776B9"
+    "accessKey": "",
+    "secretKey": ""
   },
-  "applicationId": "591a253247dc200012bee734",
+  "applicationId": "",
   "params": [
     {
       "options": {


### PR DESCRIPTION
Object keys order is not guaranteed, please refer to section [9.1.11](https://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-enumerate).

> Return an Iterator object (25.1.1.2) whose next method iterates over all the String-valued keys of enumerable properties of O. The Iterator object must inherit from %IteratorPrototype% (25.1.2). The mechanics and order of enumerating the properties is not specified but must conform to the rules specified below.

The previous unit-test implementation was not likely to fail when not using Property Keys Reordering but the implementation I'm proposing takes into account the fact that the properties key order is not guaranteed by all browsers; will not fail even when using Property Keys Reordering; and also I'm assuming that the order of the query part string is not relevant for you.